### PR TITLE
Don't die when user adds enumerable properties to Array.prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,7 @@ internals.Topo.prototype._sort = function () {
 
         var expandedGroups = [];
         for (var groupIndex in graph[node]) {
+            if(!graph[node].propertyIsEnumerable(groupIndex)) break;
             var group = graph[node][groupIndex];
             groups[group] = groups[group] || [];
             groups[group].forEach(function (d) {
@@ -104,9 +105,11 @@ internals.Topo.prototype._sort = function () {
 
     var afterNodes = Object.keys(graphAfters);
     for (var n in afterNodes) {
+        if(!afterNodes.propertyIsEnumerable(n)) break;
         var group = afterNodes[n];
 
         for (var itemIndex in groups[group]) {
+            if(!groups[group].propertyIsEnumerable(itemIndex)) break;
             var node = groups[group][itemIndex];
             graph[node] = graph[node].concat(graphAfters[group]);
         }
@@ -117,6 +120,7 @@ internals.Topo.prototype._sort = function () {
     var ancestors = {};
     var graphNodes = Object.keys(graph);
     for (var i in graphNodes) {
+        if(!graphNodes.propertyIsEnumerable(i)) break;
         var node = graphNodes[i];
         var children = graph[node];
 

--- a/test/index.js
+++ b/test/index.js
@@ -112,4 +112,26 @@ describe('Topo', function () {
 
         done();
     });
+
+    it('allows a user to add enumerable properties to the Array object', function (done) {
+
+        var scenario = [
+            { id: '0', before: 'a' },
+            { id: '1', after: 'f', group: 'a' },
+            { id: '2', before: 'a' },
+            { id: '3', before: ['b', 'c'], group: 'a' },
+            { id: '4', after: 'c', group: 'b' },
+            { id: '5', group: 'c' },
+            { id: '6', group: 'd' },
+            { id: '7', group: 'e' },
+            { id: '8', before: 'd' },
+            { id: '9', after: 'c', group: 'a' }
+        ];
+
+        Array.prototype.bogusProperty = 'gotcha!';
+        expect(testDeps(scenario)).to.equal('0213547869');
+        done();
+        delete Array.prototype.bogusProperty;
+
+    });
 });


### PR DESCRIPTION
I was wondering why [Joi](https://github.com/spumko/joi) was failing randomly in some code I was working on, and then I found this hidden away in the depths:

``` javascript
Array.prototype.toArray = function() { return this; }
```

Topo was tripping up on it while enumerating over an array (it wasn't expecting to find a the `toArray` property!).

I know, it's a code smell to add enumerable properties to global objects, but it happens sometimes. This pull request will make Topo a little bit more resilient in the wide world of Javascript userland.
