### PR TITLE
Fix bug with usage of `before` as array.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ internals.Topo.prototype._sort = function () {
 
         // Build intermediary graph using 'before'
 
-        graph[seq] = [item.before];
+        graph[seq] = item.before;
 
         // Build second intermediary graph with 'after'
 

--- a/test/index.js
+++ b/test/index.js
@@ -57,7 +57,7 @@ describe('Topo', function () {
         var scenario = [
             { id: '0', group: 'a' },
             { id: '1', group: 'b' },
-            { id: '2', before: ['a', 'b'] },
+            { id: '2', before: ['a', 'b'] }
         ];
 
         expect(testDeps(scenario)).to.equal('201');
@@ -69,7 +69,7 @@ describe('Topo', function () {
         var scenario = [
             { id: '0', after: ['a', 'b'] },
             { id: '1', group: 'a' },
-            { id: '2', group: 'b' },
+            { id: '2', group: 'b' }
         ];
 
         expect(testDeps(scenario)).to.equal('120');

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var Code = require('code');
 var Lab = require('lab');
+var Hoek = require('hoek');
 var Topo = require('..');
 
 
@@ -51,6 +52,31 @@ describe('Topo', function () {
         done();
     });
 
+    it('sorts dependencies (before as array)', function (done) {
+
+        var scenario = [
+            { id: '0', group: 'a' },
+            { id: '1', group: 'b' },
+            { id: '2', before: ['a', 'b'] },
+        ];
+
+        expect(testDeps(scenario)).to.equal('201');
+        done();
+    });
+
+    it('sorts dependencies (after as array)', function (done) {
+
+        var scenario = [
+            { id: '0', after: ['a', 'b'] },
+            { id: '1', group: 'a' },
+            { id: '2', group: 'b' },
+        ];
+
+        expect(testDeps(scenario)).to.equal('120');
+        done();
+    });
+
+
     it('sorts dependencies (seq)', function (done) {
 
         var scenario = [
@@ -64,7 +90,7 @@ describe('Topo', function () {
         done();
     });
 
-    it('sorts dependencies (explicit)', function (done) {
+    it('sorts dependencies (explicitly using after or before)', function (done) {
 
         var set = '0123456789abcdefghijklmnopqrstuvwxyz';
         var groups = set.split('');
@@ -83,19 +109,29 @@ describe('Topo', function () {
             }
         };
 
-        var scenario = [];
+        var scenarioAfter = [];
+        var scenarioBefore = [];
         for (var i = 0, il = groups.length; i < il; ++i) {
             var item = {
                 id: groups[i],
-                group: groups[i],
-                after: i ? groups.slice(0, i) : [],
+                group: groups[i]
+            };
+            var afterMod = {
+                after: i ? groups.slice(0, i) : []
+            };
+            var beforeMod = {
                 before: groups.slice(i + 1)
             };
-            scenario.push(item);
+
+            scenarioAfter.push(Hoek.applyToDefaults(item, afterMod));
+            scenarioBefore.push(Hoek.applyToDefaults(item, beforeMod));
         }
 
-        fisherYates(scenario);
-        expect(testDeps(scenario)).to.equal(set);
+        fisherYates(scenarioAfter);
+        expect(testDeps(scenarioAfter)).to.equal(set);
+
+        fisherYates(scenarioBefore);
+        expect(testDeps(scenarioBefore)).to.equal(set);
         done();
     });
 


### PR DESCRIPTION
Resolves #9.

In exploring topo to write-up some documentation, I discovered a bug when using the `before` option as an array.  I'm submitting this bug fix before I push documentation to the same branch, as I imagine the fix would be higher priority.

A note, I believe this affects hapi when specifying a `before` option on `server.ext`.

The problem becomes apparent when expanding the intermediary graph [here](https://github.com/hapijs/topo/blob/42213ae758181c6c055b29a4c9f73776d9352b3f/lib/index.js#L94-L102).  Since each entry in `graph` was originally assigned as an array containing a single array of `before` groups ([here](https://github.com/hapijs/topo/blob/42213ae758181c6c055b29a4c9f73776d9352b3f/lib/index.js#L77)), `graphNodeItems.length` is always `1` and `group` ends-up referring to the _array_ of group items rather than an individual group item.  Then, when `group` is used as an object key, the array is coerced to a string, which might look something like `'a,b,c'`.  This isn't intended, and breaks use of the `before` option when it specifies multiple groups.  The reason this was overlooked is probably because, when `before` specifies a single group (a common test-case), the array is coerced into the desired string (e.g. `['a'] --> 'a'`).

I noticed the "explicit" test passed because the `before` and `after` options were used redundantly, so I  made that test use them each separately.  I also added two tests to ensure `before` and `after` options can be specified as arrays when performing a simple topological sort.

Docs will follow this in the upcoming days, but can certainly go in a separate PR.  Happy to describe the issue and fix in more detail if there are any questions!