### PR TITLE
Ensure groups can be named after props of Object.prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,9 +93,9 @@ internals.Topo.prototype._sort = function () {
 
     // Construct graph
 
-    const groups = {};
     const graph = {};
-    const graphAfters = {};
+    const graphAfters = Object.create(null); // A prototype can bungle lookups w/ false positives
+    const groups = Object.create(null);
 
     for (let i = 0; i < this._items.length; ++i) {
         const item = this._items[i];
@@ -132,7 +132,6 @@ internals.Topo.prototype._sort = function () {
             groups[group] = groups[group] || [];
 
             for (let k = 0; k < groups[group].length; ++k) {
-
                 expandedGroups.push(groups[group][k]);
             }
         }

--- a/test/index.js
+++ b/test/index.js
@@ -153,6 +153,18 @@ describe('Topo', () => {
         done();
     });
 
+    it('can handle groups named after properties of Object.prototype', (done) => {
+
+        const scenario = [
+            { id: '0', after: ['valueOf', 'toString'] },
+            { id: '1', group: 'valueOf' },
+            { id: '2', group: 'toString' }
+        ];
+
+        expect(testDeps(scenario)).to.equal('120');
+        done();
+    });
+
     describe('merge()', () => {
 
         it('merges objects', (done) => {


### PR DESCRIPTION
Regression test and patch for #23.  Replaces PR #24.