### PR TITLE
Cleanup sort routine, clarify usage of seq vs index

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -171,12 +171,12 @@ internals.Topo.prototype._sort = function () {
     const visited = {};
     const sorted = [];
 
-    for (let i = 0; i < this._items.length; ++i) {
+    for (let i = 0; i < this._items.length; ++i) {          // Really looping thru item.seq values out of order
         let next = i;
 
         if (ancestors[i]) {
             next = null;
-            for (let j = 0; j < this._items.length; ++j) {
+            for (let j = 0; j < this._items.length; ++j) {  // As above, these are item.seq values
                 if (visited[j] === true) {
                     continue;
                 }
@@ -188,7 +188,7 @@ internals.Topo.prototype._sort = function () {
                 const shouldSeeCount = ancestors[j].length;
                 let seenCount = 0;
                 for (let k = 0; k < shouldSeeCount; ++k) {
-                    if (sorted.indexOf(ancestors[j][k]) >= 0) {
+                    if (visited[ancestors[j][k]]) {
                         ++seenCount;
                     }
                 }
@@ -201,7 +201,6 @@ internals.Topo.prototype._sort = function () {
         }
 
         if (next !== null) {
-            next = next.toString();         // Normalize to string TODO: replace with seq
             visited[next] = true;
             sorted.push(next);
         }


### PR DESCRIPTION
There's been a long-standing TODO in topo (pre-dating my involvement) that I think is finally resolved.  Beyond that there is some minor code cleanup in the sort routine.  Two things to cover,

1. I use a `visited` dictionary lookup rather than `sorted.indexOf()` to check for visited nodes.  This is preferable because it's quicker/cleaner and because it allows us to get rid of the confusing `next = next.toString()` line.  That line existed to account for the `ancestors` values being `item.seq` values (numbers) that were taken from `Object.keys()` (so actually, numbers coerced into to strings).  Now we simply continue to deal with object keys, where the string conversion occurs implicitly.

2. I added some comments to the main topo-sort loops, clarifying that looping over the item indices is the same as looping over the `item.seq` values, just "out of order."  The `item.seq` values are always assigned as the current length of the items list, so there's a one-to-one correspondence between `item.seq` values and item list indices.  I believe this clarification is good enough to nix the TODO in the codebase.

Since TODOs are not allowed by the hapi style guide, let's simply create an issue if this does not in fact resolve the pre-existing TODO.

@hueniverse I put this up as a PR in case you might have time to take a peek, given that it deals with a fairly nuanced area of topo and because you added the original TODO.