### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "topsort"
   ],
   "engines": {
-    "node": ">=8.12.0"
+    "node": ">=8.9.0"
   },
   "dependencies": {
     "hoek": "6.x.x"


### PR DESCRIPTION
Node 8.12.0 is not supported by Alpine 3.8, only by Alpine edge, which is a major problem when installing the latest topo version. The upgrade to enforce Node 8.12 in a minor upgrade breaks builds. Please revert this change (and if applicable, revert the reason for making this change in the first place)