### PR TITLE
Fix readme to point to correct module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See the [API Reference](API.md)
 
 **Example**
 ```js
-const Topo = require('topo');
+const Topo = require('@hapi/topo');
 
 const morning = new Topo();
 


### PR DESCRIPTION
Just realized that `topo` was deprecated and hasn't received updates. :upside_down_face: 