### PR TITLE
Adjust hoek to `^8.2.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lib"
   ],
   "dependencies": {
-    "@hapi/hoek": "^8.2.x"
+    "@hapi/hoek": "^8.3.0"
   },
   "devDependencies": {
     "@hapi/code": "6.x.x",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lib"
   ],
   "dependencies": {
-    "@hapi/hoek": "8.x.x"
+    "@hapi/hoek": "^8.2.x"
   },
   "devDependencies": {
     "@hapi/code": "6.x.x",


### PR DESCRIPTION
This change is to use the `assert()` function exposed by the `hoek` API rather than reaching for the specific assert file. While the package.json lists `@hapi/hoek` at version `8.x.x`, the `@hapi/hoek/lib/assert` file was not added until version `8.2.0`. This problem affects those with package-lock files where `@hapi/hoek` is at version < `8.2.0`.