### PR TITLE
Support manual sorting (performance)

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,7 @@ Returns an array of the topologically sorted nodes (unless `manual` is used in w
 ### `sorter.nodes`
 
 An array of the topologically sorted nodes.  This list is renewed upon each call to [`sorter.add()`](#topoaddnodes-options) unless
-the `manual` is used.
+`manual` is used.
 
 ### `sorter.merge(others)`
 

--- a/API.md
+++ b/API.md
@@ -38,11 +38,12 @@ Specifies an additional node or list of nodes to be topologically sorted where:
     - `sort` - a numerical value used to sort items when performing a `sorter.merge()`.
     - `manual` - if `true`, the array is not sorted automatically and `sorter.sort()` must be called when done adding items.
 
-Returns an array of the topologically sorted nodes (unless `manual` is used in which case the array is unsorted).
+Returns an array of the topologically sorted nodes (unless `manual` is used in which case the array is left unchanged).
 
 ### `sorter.nodes`
 
-An array of the topologically sorted nodes.  This list is renewed upon each call to [`sorter.add()`](#topoaddnodes-options).
+An array of the topologically sorted nodes.  This list is renewed upon each call to [`sorter.add()`](#topoaddnodes-options) unless
+the `manual` is used.
 
 ### `sorter.merge(others)`
 

--- a/API.md
+++ b/API.md
@@ -36,8 +36,9 @@ Specifies an additional node or list of nodes to be topologically sorted where:
     - `before` - a string or array of strings specifying the groups that `nodes` must precede in the topological sort.
     - `after` - a string or array of strings specifying the groups that `nodes` must succeed in the topological sort.
     - `sort` - a numerical value used to sort items when performing a `sorter.merge()`.
+    - `manual` - if `true`, the array is not sorted automatically and `sorter.sort()` must be called when done adding items.
 
-Returns an array of the topologically sorted nodes.
+Returns an array of the topologically sorted nodes (unless `manual` is used in which case the array is unsorted).
 
 ### `sorter.nodes`
 
@@ -54,3 +55,9 @@ combined items.
 
 If the order in which items have been added to each list matters, use the `sort` option in `sorter.add()` with an incrementing
 value providing an absolute sort order among all items added to either object.
+
+### `sorter.sort()`
+
+Sorts the array. Only needed if the `manual` option is used when `add()` is called.
+
+Returns an array of the topologically sorted nodes. Will throw if a dependency error is found.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -23,6 +23,11 @@ export class Sorter<T> {
      * @returns Returns an array of the topologically sorted nodes.
      */
     merge(others: Sorter<T> | Sorter<T>[]): T[];
+
+    /**
+     * Sorts the nodes array (only required if the manual option is used when adding items)
+     */
+    sort(): T[];
 }
 
 
@@ -47,4 +52,9 @@ export interface Options {
      * A number used to sort items with equal before/after requirements
      */
     readonly sort?: number;
+
+    /**
+     * If true, the array is not sorted automatically until sort() is called
+     */
+    readonly manual?: boolean;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,10 @@ exports.Sorter = class {
 
         // Insert event
 
-        const valid = this._sort();
-        Assert(valid, 'item', group !== '?' ? `added into group ${group}` : '', 'created a dependencies error');
+        if (!options.manual) {
+            const valid = this._sort();
+            Assert(valid, 'item', group !== '?' ? `added into group ${group}` : '', 'created a dependencies error');
+        }
 
         return this.nodes;
     }
@@ -78,6 +80,14 @@ exports.Sorter = class {
 
         const valid = this._sort();
         Assert(valid, 'merge created a dependencies error');
+
+        return this.nodes;
+    }
+
+    sort() {
+
+        const valid = this._sort();
+        Assert(valid, 'sort created a dependencies error');
 
         return this.nodes;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -18,11 +18,10 @@ describe('Sorter', () => {
     const testDeps = function (scenario) {
 
         const topo = new Topo.Sorter();
-        scenario.forEach((record, i) => {
-
+        for (const record of scenario) {
             const options = record.before || record.after || record.group ? { before: record.before, after: record.after, group: record.group } : null;
             topo.add(record.id, options);
-        });
+        }
 
         return topo.nodes.join('');
     };
@@ -43,6 +42,30 @@ describe('Sorter', () => {
         ];
 
         expect(testDeps(scenario)).to.equal('0213547869');
+    });
+
+    it('sorts dependencies (manual)', () => {
+
+        const scenario = [
+            { id: '0', before: 'a' },
+            { id: '1', after: 'f', group: 'a' },
+            { id: '2', before: 'a' },
+            { id: '3', before: ['b', 'c'], group: 'a' },
+            { id: '4', after: 'c', group: 'b' },
+            { id: '5', group: 'c' },
+            { id: '6', group: 'd' },
+            { id: '7', group: 'e' },
+            { id: '8', before: 'd' },
+            { id: '9', after: 'c', group: 'a' }
+        ];
+
+        const topo = new Topo.Sorter();
+        for (const record of scenario) {
+            const options = record.before || record.after || record.group ? { before: record.before, after: record.after, group: record.group } : null;
+            topo.add(record.id, { ...options, manual: true });
+        }
+
+        expect(topo.sort().join('')).to.equal('0213547869');
     });
 
     it('sorts dependencies (before as array)', () => {
@@ -66,7 +89,6 @@ describe('Sorter', () => {
 
         expect(testDeps(scenario)).to.equal('120');
     });
-
 
     it('sorts dependencies (seq)', () => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -65,7 +65,9 @@ describe('Sorter', () => {
             topo.add(record.id, { ...options, manual: true });
         }
 
+        expect(topo.nodes.join('')).to.equal('');
         expect(topo.sort().join('')).to.equal('0213547869');
+        expect(topo.nodes.join('')).to.equal('0213547869');
     });
 
     it('sorts dependencies (before as array)', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -37,6 +37,12 @@ expect.type<string[]>(morning.nodes);
 expect.type<string[]>(afternoon.nodes);
 
 
-// sorter.merge
+// sorter.merge()
 
 expect.type<string[]>(morning.merge(afternoon));
+
+
+// sorter.sort()
+
+expect.type<string[]>(morning.sort());
+expect.error(morning.sort([]));


### PR DESCRIPTION
Adds the option to delay sorting the array until all the nodes are added. This can make the operation up to 4 times faster.