### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v6
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,14 +16,14 @@ exports.Sorter = class {
 
     add(nodes, options) {
 
-        options = options || {};
+        options = options ?? {};
 
         // Validate rules
 
-        const before = [].concat(options.before || []);
-        const after = [].concat(options.after || []);
-        const group = options.group || '?';
-        const sort = options.sort || 0;                   // Used for merging only
+        const before = [].concat(options.before ?? []);
+        const after = [].concat(options.after ?? []);
+        const group = options.group ?? '?';
+        const sort = options.sort ?? 0;                   // Used for merging only
 
         Assert(!before.includes(group), `Item cannot come before itself: ${group}`);
         Assert(!before.includes('?'), 'Item cannot come before unassociated items');
@@ -106,7 +106,7 @@ exports.Sorter = class {
 
             // Determine Groups
 
-            groups[group] = groups[group] || [];
+            groups[group] = groups[group] ?? [];
             groups[group].push(seq);
 
             // Build intermediary graph using 'before'
@@ -116,7 +116,7 @@ exports.Sorter = class {
             // Build second intermediary graph with 'after'
 
             for (const after of item.after) {
-                graphAfters[after] = graphAfters[after] || [];
+                graphAfters[after] = graphAfters[after] ?? [];
                 graphAfters[after].push(seq);
             }
         }
@@ -128,7 +128,7 @@ exports.Sorter = class {
 
             for (const graphNodeItem in graph[node]) {
                 const group = graph[node][graphNodeItem];
-                groups[group] = groups[group] || [];
+                groups[group] = groups[group] ?? [];
                 expandedGroups.push(...groups[group]);
             }
 
@@ -151,7 +151,7 @@ exports.Sorter = class {
         for (const node in graph) {
             const children = graph[node];
             for (const child of children) {
-                ancestors[child] = ancestors[child] || [];
+                ancestors[child] = ancestors[child] ?? [];
                 ancestors[child].push(node);
             }
         }

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.0"
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "9.x.x",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
+    "@hapi/lab": "25.0.0-beta.1",
     "@types/node": "^17.0.31",
-    "typescript": "~4.0.2"
+    "typescript": "^4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "9.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "25.0.0-beta.1",
     "@types/node": "^17.0.31",
-    "typescript": "^4.6.4"
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update typescript and node v18-compatible versions of hoek, lab, and code.

If this looks good, this will go out as topo v6.